### PR TITLE
Add leave type allocation filter

### DIFF
--- a/gia_hr_custom/__manifest__.py
+++ b/gia_hr_custom/__manifest__.py
@@ -13,6 +13,7 @@
         'views/hr_salary_rule_views.xml',
         'views/hr_salary_component_type_views.xml',
         'views/hr_payslip_run_views.xml',
+        'views/hr_leave_balance_report_views.xml',
 
     ],
     'installable': True,

--- a/gia_hr_custom/models/__init__.py
+++ b/gia_hr_custom/models/__init__.py
@@ -4,4 +4,5 @@ from . import hr_salary_rule
 from . import hr_salary_component_type
 from . import hr_payslip
 from . import hr_payslip_run
+from . import hr_leave_balance_report
 

--- a/gia_hr_custom/models/hr_leave_balance_report.py
+++ b/gia_hr_custom/models/hr_leave_balance_report.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, tools
+
+
+class HrLeaveBalanceReport(models.Model):
+    _name = 'hr.leave.balance.report'
+    _description = 'Leave Balance Report'
+    _auto = False
+    _order = 'employee_id, holiday_status_id'
+
+    employee_id = fields.Many2one('hr.employee', string='Employee', readonly=True)
+    holiday_status_id = fields.Many2one('hr.leave.type', string='Time Off Type', readonly=True)
+    allocated_days = fields.Float(string='Allocated', readonly=True)
+    taken_days = fields.Float(string='Taken', readonly=True)
+    remaining_days = fields.Float(string='Remaining', readonly=True)
+    date_from = fields.Datetime(string='Start Date', readonly=True)
+    company_id = fields.Many2one('res.company', string='Company', readonly=True)
+
+    def init(self):
+        tools.drop_view_if_exists(self._cr, 'hr_leave_balance_report')
+        self._cr.execute("""
+            CREATE OR REPLACE VIEW hr_leave_balance_report AS (
+                SELECT
+                    row_number() OVER(ORDER BY lr.employee_id, lr.holiday_status_id) AS id,
+                    lr.employee_id AS employee_id,
+                    lr.holiday_status_id AS holiday_status_id,
+                    lr.company_id AS company_id,
+                    MIN(lr.date_from) AS date_from,
+                    SUM(CASE WHEN lr.leave_type = 'allocation' THEN lr.number_of_days ELSE 0 END) AS allocated_days,
+                    SUM(CASE WHEN lr.leave_type = 'request' THEN -lr.number_of_days ELSE 0 END) AS taken_days,
+                    SUM(lr.number_of_days) AS remaining_days
+                FROM hr_leave_report lr
+                JOIN hr_leave_type lt ON lt.id = lr.holiday_status_id
+                WHERE lr.state = 'validate'
+                  AND lt.requires_allocation = 'yes'
+                GROUP BY lr.employee_id, lr.holiday_status_id, lr.company_id
+            )
+        """)
+

--- a/gia_hr_custom/security/ir.model.access.csv
+++ b/gia_hr_custom/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_hr_job_grade,access_hr_job_grade,model_hr_job_grade,,1,1,1,1
 access_hr_employee_group,access_hr_employee_group,model_hr_employee_group,,1,1,1,1
 access_hr_salary_component_type,access_hr_salary_component_type,model_hr_salary_component_type,hr_payroll.group_hr_payroll_user,1,1,1,1
+access_hr_leave_balance_report,access_hr_leave_balance_report,model_hr_leave_balance_report,base.group_user,1,0,0,0

--- a/gia_hr_custom/views/hr_leave_balance_report_views.xml
+++ b/gia_hr_custom/views/hr_leave_balance_report_views.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_leave_balance_report_tree" model="ir.ui.view">
+        <field name="name">hr.leave.balance.report.tree</field>
+        <field name="model">hr.leave.balance.report</field>
+        <field name="arch" type="xml">
+            <tree sample="1">
+                <field name="employee_id"/>
+                <field name="holiday_status_id"/>
+                <field name="allocated_days" sum="Allocated"/>
+                <field name="taken_days" sum="Taken"/>
+                <field name="remaining_days" sum="Remaining"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="hr_leave_balance_report_search" model="ir.ui.view">
+        <field name="name">hr.leave.balance.report.search</field>
+        <field name="model">hr.leave.balance.report</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="employee_id"/>
+                <filter name="filter_date_from" date="date_from" default_period="this_year" string="Current Year"/>
+                <group expand="0" string="Group By">
+                    <filter name="group_employee" string="Employee" context="{'group_by':'employee_id'}"/>
+                    <filter name="group_type" string="Type" context="{'group_by':'holiday_status_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="hr_leave_balance_report_action" model="ir.actions.act_window">
+        <field name="name">Leave Balance Report</field>
+        <field name="res_model">hr.leave.balance.report</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="hr_leave_balance_report_tree"/>
+        <field name="search_view_id" ref="hr_leave_balance_report_search"/>
+        <field name="context">{'search_default_filter_date_from': 1, 'search_default_group_employee': 1, 'search_default_group_type': 1}</field>
+    </record>
+
+    <menuitem id="menu_hr_leave_balance_report" name="Leave Balance" parent="hr_holidays.menu_hr_holidays_report" action="hr_leave_balance_report_action" sequence="5"/>
+</odoo>
+


### PR DESCRIPTION
## Summary
- filter leave balance SQL view to show only leave types that require allocation
- allow searching by employee name

## Testing
- `python -m py_compile gia_hr_custom/models/hr_leave_balance_report.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_68583665ce2c8329b6f9271ea487b8bf